### PR TITLE
get model coefficients, not the function

### DIFF
--- a/R/ml_classification_logistic_regression.R
+++ b/R/ml_classification_logistic_regression.R
@@ -369,7 +369,7 @@ new_ml_model_logistic_regression <- function(
         c("(Intercept)", feature_names)
       )
     else
-      rlang::set_names(coefficients, feature_names)
+      rlang::set_names(model$coefficients, feature_names)
     coefficients
   }
 


### PR DESCRIPTION
As this was written, I believe `coefficients` was referencing a function, not the model's coefficients.
Hoping this will fix #1596